### PR TITLE
IRBuilder now uses the new class types instead of the C-style structs

### DIFF
--- a/Conversions.cs
+++ b/Conversions.cs
@@ -21,6 +21,15 @@
 
     partial struct LLVMValueRef
     {
+        internal static LLVMValueRef[] FromArray(Value[] source)
+        {
+            var length = source.Length;
+            var target = new LLVMValueRef[length];
+            for (var i = 0; i < length; i++)
+                target[i] = source[i];
+            return target;
+        }
+
         public static implicit operator bool(LLVMValueRef v)
         {
             return v.Pointer != IntPtr.Zero;
@@ -294,6 +303,14 @@
             }
 
             return new Constant(v);
+        }
+    }
+
+    partial struct LLVMTypeRef
+    {
+        public static implicit operator LLVMTypeRef(Type type)
+        {
+            return type.TypeRef;
         }
     }
 }

--- a/IRBuilder.cs
+++ b/IRBuilder.cs
@@ -1,425 +1,541 @@
 ﻿namespace LLVMSharp
 {
-    public sealed class IRBuilder
+    using System;
+
+    public sealed class IRBuilder : IDisposable
     {
         private readonly LLVMBuilderRef instance;
 
-        public IRBuilder(LLVMBuilderRef instance)
+        private bool disposed;
+
+        public IRBuilder(LLVMContextRef context)
         {
-            this.instance = instance;
+            instance = LLVM.CreateBuilderInContext(context);
         }
 
-        public void PositionBuilder(LLVMBasicBlockRef @Block, LLVMValueRef @Instr)
+        public IRBuilder() : this(LLVM.GetGlobalContext())
+        {
+        }
+
+        ~IRBuilder()
+        {
+            Dispose(false);
+        }
+
+        public void PositionBuilder(BasicBlock @Block, Value @Instr)
         {
             LLVM.PositionBuilder(this.instance, @Block, @Instr);
         }
 
-        public void PositionBuilderBefore(LLVMValueRef @Instr)
+        public void PositionBuilderBefore(Value @Instr)
         {
             LLVM.PositionBuilderBefore(this.instance, @Instr);
         }
 
-        public void PositionBuilderAtEnd(LLVMBasicBlockRef @Block)
+        public void PositionBuilderAtEnd(BasicBlock @Block)
         {
             LLVM.PositionBuilderAtEnd(this.instance, @Block);
         }
 
-        public LLVMBasicBlockRef GetInsertBlock()
+        public BasicBlock GetInsertBlock()
         {
-            return LLVM.GetInsertBlock(this.instance);
+            return new BasicBlock(LLVM.GetInsertBlock(instance));
         }
 
         public void ClearInsertionPosition()
         {
-            LLVM.ClearInsertionPosition(this.instance);
+            LLVM.ClearInsertionPosition(instance);
         }
 
-        public void InsertIntoBuilder(LLVMValueRef @Instr)
+        public void InsertIntoBuilder(Value @Instr)
         {
             LLVM.InsertIntoBuilder(this.instance, @Instr);
         }
 
-        public void InsertIntoBuilderWithName(LLVMValueRef @Instr, string @Name)
+        public void InsertIntoBuilderWithName(Value @Instr, string @Name)
         {
             LLVM.InsertIntoBuilderWithName(this.instance, @Instr, @Name);
         }
 
-        public void DisposeBuilder()
+        public void Dispose()
         {
-            LLVM.DisposeBuilder(this.instance);
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
-        public void SetCurrentDebugLocation(LLVMValueRef @L)
+        private void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            LLVM.DisposeBuilder(instance);
+
+            disposed = true;
+        }
+
+        public void SetCurrentDebugLocation(Value @L)
         {
             LLVM.SetCurrentDebugLocation(this.instance, @L);
         }
 
-        public LLVMValueRef GetCurrentDebugLocation()
+        public Value GetCurrentDebugLocation()
         {
-            return LLVM.GetCurrentDebugLocation(this.instance);
+            return LLVM.GetCurrentDebugLocation(instance);
         }
 
-        public void SetInstDebugLocation(LLVMValueRef @Inst)
+        public void SetInstDebugLocation(Value @Inst)
         {
             LLVM.SetInstDebugLocation(this.instance, @Inst);
         }
 
+        public Value CreateRetVoid()
         {
-            return LLVM.BuildRetVoid(this.instance);
+            return LLVM.BuildRetVoid(instance);
         }
 
+        public Value CreateRet(Value @V)
         {
             return LLVM.BuildRet(this.instance, @V);
         }
 
+        public Value CreateAggregateRet(Value[] @RetVals)
         {
-            return LLVM.BuildAggregateRet(this.instance, out @RetVals[0], (uint)@RetVals.Length);
+            return LLVM.BuildAggregateRet(this.instance, LLVMValueRef.FromArray(@RetVals));
         }
 
+        public Value CreateBr(BasicBlock @Dest)
         {
             return LLVM.BuildBr(this.instance, @Dest);
         }
 
+        public Value CreateCondBr(Value @If, BasicBlock @Then, BasicBlock @Else)
         {
             return LLVM.BuildCondBr(this.instance, @If, @Then, @Else);
         }
 
+        public Value CreateSwitch(Value @V, BasicBlock @Else, uint @NumCases)
         {
             return LLVM.BuildSwitch(this.instance, @V, @Else, @NumCases);
         }
 
+        public Value CreateIndirectBr(Value @Addr, uint @NumDests)
         {
             return LLVM.BuildIndirectBr(this.instance, @Addr, @NumDests);
         }
 
+        public Value CreateInvoke(Value @Fn, Value[] @Args, BasicBlock @Then, BasicBlock @Catch, string @Name)
         {
-            return LLVM.BuildInvoke(this.instance, @Fn, Args, @Then, @Catch, @Name);
+            return LLVM.BuildInvoke(this.instance, @Fn, LLVMValueRef.FromArray(Args), @Then, @Catch, @Name);
         }
 
+        public Value CreateLandingPad(Type @Ty, Value @PersFn, uint @NumClauses, string @Name)
         {
             return LLVM.BuildLandingPad(this.instance, @Ty, @PersFn, @NumClauses, @Name);
         }
 
+        public Value CreateResume(Value @Exn)
         {
             return LLVM.BuildResume(this.instance, @Exn);
         }
 
+        public Value CreateUnreachable()
         {
-            return LLVM.BuildUnreachable(this.instance);
+            return LLVM.BuildUnreachable(instance);
         }
 
+        public Value CreateAdd(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildAdd(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNSWAdd(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildNSWAdd(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNUWAdd(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildNUWAdd(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFAdd(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildFAdd(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateSub(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildSub(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNSWSub(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildNSWSub(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNUWSub(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildNUWSub(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFSub(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildFSub(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateMul(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildMul(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNSWMul(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildNSWMul(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNUWMul(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildNUWMul(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFMul(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildFMul(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateUDiv(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildUDiv(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateSDiv(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildSDiv(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateExactSDiv(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildExactSDiv(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFDiv(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildFDiv(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateURem(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildURem(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateSRem(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildSRem(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFRem(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildFRem(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateShl(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildShl(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateLShr(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildLShr(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateAShr(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildAShr(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateAnd(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildAnd(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateOr(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildOr(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateXor(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildXor(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateBinOp(LLVMOpcode @Op, Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildBinOp(this.instance, @Op, @LHS, @RHS, @Name);
         }
 
+        public Value CreateNeg(Value @V, string @Name)
         {
             return LLVM.BuildNeg(this.instance, @V, @Name);
         }
 
+        public Value CreateNSWNeg(Value @V, string @Name)
         {
             return LLVM.BuildNSWNeg(this.instance, @V, @Name);
         }
 
+        public Value CreateNUWNeg(Value @V, string @Name)
         {
             return LLVM.BuildNUWNeg(this.instance, @V, @Name);
         }
 
+        public Value CreateFNeg(Value @V, string @Name)
         {
             return LLVM.BuildFNeg(this.instance, @V, @Name);
         }
 
+        public Value CreateNot(Value @V, string @Name)
         {
             return LLVM.BuildNot(this.instance, @V, @Name);
         }
 
+        public Value CreateMalloc(Type @Ty, string @Name)
         {
             return LLVM.BuildMalloc(this.instance, @Ty, @Name);
         }
 
+        public Value CreateArrayMalloc(Type @Ty, Value @Val, string @Name)
         {
             return LLVM.BuildArrayMalloc(this.instance, @Ty, @Val, @Name);
         }
 
+        public Value CreateAlloca(Type @Ty, string @Name)
         {
             return LLVM.BuildAlloca(this.instance, @Ty, @Name);
         }
 
+        public Value CreateArrayAlloca(Type @Ty, Value @Val, string @Name)
         {
             return LLVM.BuildArrayAlloca(this.instance, @Ty, @Val, @Name);
         }
 
+        public Value CreateFree(Value @PointerVal)
         {
             return LLVM.BuildFree(this.instance, @PointerVal);
         }
 
+        public Value CreateLoad(Value @PointerVal, string @Name)
         {
             return LLVM.BuildLoad(this.instance, @PointerVal, @Name);
         }
 
+        public Value CreateStore(Value @Val, Value @Ptr)
         {
             return LLVM.BuildStore(this.instance, @Val, @Ptr);
         }
 
+        public Value CreateGEP(Value @Pointer, Value[] @Indices, string @Name)
         {
-            return LLVM.BuildGEP(this.instance, @Pointer, @Indices, @Name);
+            return LLVM.BuildGEP(this.instance, @Pointer, LLVMValueRef.FromArray(Indices), @Name);
         }
 
+        public Value CreateInBoundsGEP(Value @Pointer, Value[] @Indices, string @Name)
         {
-            return LLVM.BuildInBoundsGEP(this.instance, @Pointer, @Indices, @Name);
+            return LLVM.BuildInBoundsGEP(this.instance, @Pointer, LLVMValueRef.FromArray(@Indices), @Name);
         }
 
+        public Value CreateStructGEP(Value @Pointer, uint @Idx, string @Name)
         {
             return LLVM.BuildStructGEP(this.instance, @Pointer, @Idx, @Name);
         }
 
+        public Value CreateGlobalString(string @Str, string @Name)
         {
             return LLVM.BuildGlobalString(this.instance, @Str, @Name);
         }
 
+        public Value CreateGlobalStringPtr(string @Str, string @Name)
         {
             return LLVM.BuildGlobalStringPtr(this.instance, @Str, @Name);
         }
 
+        public Value CreateTrunc(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildTrunc(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateZExt(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildZExt(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateSExt(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildSExt(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateFPToUI(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildFPToUI(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateFPToSI(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildFPToSI(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateUIToFP(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildUIToFP(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateSIToFP(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildSIToFP(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateFPTrunc(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildFPTrunc(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateFPExt(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildFPExt(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreatePtrToInt(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildPtrToInt(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateIntToPtr(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildIntToPtr(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateBitCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildBitCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateAddrSpaceCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildAddrSpaceCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateZExtOrBitCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildZExtOrBitCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateSExtOrBitCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildSExtOrBitCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateTruncOrBitCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildTruncOrBitCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateCast(LLVMOpcode @Op, Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildCast(this.instance, @Op, @Val, @DestTy, @Name);
         }
 
+        public Value CreatePointerCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildPointerCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateIntCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildIntCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateFPCast(Value @Val, Type @DestTy, string @Name)
         {
             return LLVM.BuildFPCast(this.instance, @Val, @DestTy, @Name);
         }
 
+        public Value CreateICmp(LLVMIntPredicate @Op, Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildICmp(this.instance, @Op, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFCmp(LLVMRealPredicate @Op, Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildFCmp(this.instance, @Op, @LHS, @RHS, @Name);
         }
 
+        public Value CreatePhi(Type @Ty, string @Name)
         {
             return LLVM.BuildPhi(this.instance, @Ty, @Name);
         }
 
+        public Value CreateCall(Value @Fn, Value[] @Args, string @Name)
         {
-            return LLVM.BuildCall(this.instance, @Fn, @Args, @Name);
+            return LLVM.BuildCall(this.instance, @Fn, LLVMValueRef.FromArray(@Args), @Name);
         }
 
+        public Value CreateSelect(Value @If, Value @Then, Value @Else, string @Name)
         {
             return LLVM.BuildSelect(this.instance, @If, @Then, @Else, @Name);
         }
 
+        public Value CreateVAArg(Value @List, Type @Ty, string @Name)
         {
             return LLVM.BuildVAArg(this.instance, @List, @Ty, @Name);
         }
 
+        public Value CreateExtractElement(Value @VecVal, Value @Index, string @Name)
         {
             return LLVM.BuildExtractElement(this.instance, @VecVal, @Index, @Name);
         }
 
+        public Value CreateInsertElement(Value @VecVal, Value @EltVal, Value @Index, string @Name)
         {
             return LLVM.BuildInsertElement(this.instance, @VecVal, @EltVal, @Index, @Name);
         }
 
+        public Value CreateShuffleVector(Value @V1, Value @V2, Value @Mask, string @Name)
         {
             return LLVM.BuildShuffleVector(this.instance, @V1, @V2, @Mask, @Name);
         }
 
+        public Value CreateExtractValue(Value @AggVal, uint @Index, string @Name)
         {
             return LLVM.BuildExtractValue(this.instance, @AggVal, @Index, @Name);
         }
 
+        public Value CreateInsertValue(Value @AggVal, Value @EltVal, uint @Index, string @Name)
         {
             return LLVM.BuildInsertValue(this.instance, @AggVal, @EltVal, @Index, @Name);
         }
 
+        public Value CreateIsNull(Value @Val, string @Name)
         {
             return LLVM.BuildIsNull(this.instance, @Val, @Name);
         }
 
+        public Value CreateIsNotNull(Value @Val, string @Name)
         {
             return LLVM.BuildIsNotNull(this.instance, @Val, @Name);
         }
 
+        public Value CreatePtrDiff(Value @LHS, Value @RHS, string @Name)
         {
             return LLVM.BuildPtrDiff(this.instance, @LHS, @RHS, @Name);
         }
 
+        public Value CreateFence(LLVMAtomicOrdering @ordering, bool @singleThread, string @Name)
         {
             return LLVM.BuildFence(this.instance, @ordering, @singleThread, @Name);
         }
 
+        public Value CreateAtomicRMW(LLVMAtomicRMWBinOp @op, Value @PTR, Value @Val, LLVMAtomicOrdering @ordering, bool @singleThread)
         {
             return LLVM.BuildAtomicRMW(this.instance, @op, @PTR, @Val, @ordering, @singleThread);
         }

--- a/Overloads.cs
+++ b/Overloads.cs
@@ -1,16 +1,20 @@
 ﻿namespace LLVMSharp
 {
+    using System;
+
     partial class LLVM
     {
-        public static LLVMValueRef BuildCall(LLVMBuilderRef param0, LLVMValueRef Fn, LLVMValueRef[] Args, string Name)
+        public static LLVMValueRef[] GetNamedMetadataOperands(LLVMModuleRef M, string name)
         {
-            if (Args.Length == 0)
+            uint count = GetNamedMetadataNumOperands(M, name);
+            var buffer = new LLVMValueRef[count];
+
+            if (count > 0)
             {
-                LLVMValueRef dummy;
-                return BuildCall(param0, Fn, out dummy, 0, Name);
+                GetNamedMetadataOperands(M, name, out buffer[0]);
             }
 
-            return BuildCall(param0, Fn, out Args[0], (uint)Args.Length, Name);
+            return buffer;
         }
 
         public static LLVMTypeRef FunctionType(LLVMTypeRef ReturnType, LLVMTypeRef[] ParamTypes, LLVMBool IsVarArg)
@@ -24,16 +28,17 @@
             return FunctionType(ReturnType, out ParamTypes[0], (uint)ParamTypes.Length, IsVarArg);
         }
 
-        public static void StructSetBody(LLVMTypeRef StructTy, LLVMTypeRef[] ElementTypes, LLVMBool Packed)
+        public static LLVMTypeRef[] GetParamTypes(LLVMTypeRef FunctionTy)
         {
-            if (ElementTypes.Length == 0)
+            uint count = CountParamTypes(FunctionTy);
+            var buffer = new LLVMTypeRef[count];
+
+            if (count > 0)
             {
-                LLVMTypeRef dummy;
-                StructSetBody(StructTy, out dummy, 0, Packed);
-                return;
+                GetParamTypes(FunctionTy, out buffer[0]);
             }
 
-            StructSetBody(StructTy, out ElementTypes[0], (uint)ElementTypes.Length, Packed);
+            return buffer;
         }
 
         public static LLVMTypeRef StructTypeInContext(LLVMContextRef C, LLVMTypeRef[] ElementTypes, LLVMBool Packed)
@@ -56,6 +61,31 @@
             }
 
             return StructType(out ElementTypes[0], (uint)ElementTypes.Length, Packed);
+        }
+
+        public static void StructSetBody(LLVMTypeRef StructTy, LLVMTypeRef[] ElementTypes, LLVMBool Packed)
+        {
+            if (ElementTypes.Length == 0)
+            {
+                LLVMTypeRef dummy;
+                StructSetBody(StructTy, out dummy, 0, Packed);
+                return;
+            }
+
+            StructSetBody(StructTy, out ElementTypes[0], (uint)ElementTypes.Length, Packed);
+        }
+
+        public static LLVMTypeRef[] GetStructElementTypes(LLVMTypeRef StructTy)
+        {
+            uint count = CountStructElementTypes(StructTy);
+            var buffer = new LLVMTypeRef[count];
+
+            if (count > 0)
+            {
+                GetStructElementTypes(StructTy, out buffer[0]);
+            }
+
+            return buffer;
         }
 
         public static LLVMValueRef ConstStructInContext(LLVMContextRef C, LLVMValueRef[] ConstantVals, LLVMBool Packed)
@@ -146,8 +176,7 @@
             return ConstExtractValue(AggConstant, out IdxList[0], (uint)IdxList.Length);
         }
 
-        public static LLVMValueRef ConstInsertValue(LLVMValueRef AggConstant, LLVMValueRef ElementValueConstant,
-            uint[] IdxList)
+        public static LLVMValueRef ConstInsertValue(LLVMValueRef AggConstant, LLVMValueRef ElementValueConstant, uint[] IdxList)
         {
             if (IdxList.Length == 0)
             {
@@ -156,6 +185,19 @@
             }
 
             return ConstInsertValue(AggConstant, ElementValueConstant, out IdxList[0], (uint)IdxList.Length);
+        }
+
+        public static LLVMValueRef[] GetParams(LLVMValueRef Fn)
+        {
+            uint count = CountParams(Fn);
+            var buffer = new LLVMValueRef[count];
+
+            if (count > 0)
+            {
+                GetParams(Fn, out buffer[0]);
+            }
+
+            return buffer;
         }
 
         public static LLVMValueRef MDNodeInContext(LLVMContextRef C, LLVMValueRef[] Vals)
@@ -180,8 +222,48 @@
             return MDNode(out Vals[0], (uint)Vals.Length);
         }
 
-        public static LLVMValueRef BuildInvoke(LLVMBuilderRef param0, LLVMValueRef Fn, LLVMValueRef[] Args,
-            LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, string Name)
+        public static LLVMValueRef[] GetMDNodeOperands(LLVMValueRef V)
+        {
+            uint count = GetMDNodeNumOperands(V);
+            var buffer = new LLVMValueRef[count];
+
+            if (count > 0)
+            {
+                GetMDNodeOperands(V, out buffer[0]);
+            }
+
+            return buffer;
+        }
+
+        public static LLVMBasicBlockRef[] GetBasicBlocks(LLVMValueRef Fn)
+        {
+            uint count = CountBasicBlocks(Fn);
+            var buffer = new LLVMBasicBlockRef[count];
+
+            if (count > 0)
+            {
+                GetBasicBlocks(Fn, out buffer[0]);
+            }
+
+            return buffer;
+        }
+
+        public static void AddIncoming(LLVMValueRef PhiNode, LLVMValueRef[] IncomingValues, LLVMBasicBlockRef[] IncomingBlocks, uint Count)
+        {
+            if (Count == 0)
+            {
+                return;
+            }
+
+            AddIncoming(PhiNode, out IncomingValues[0], out IncomingBlocks[0], Count);
+        }
+
+        public static LLVMValueRef BuildAggregateRet(LLVMBuilderRef param0, LLVMValueRef[] RetVals)
+        {
+            return BuildAggregateRet(param0, out RetVals[0], (uint)RetVals.Length);
+        }
+
+        public static LLVMValueRef BuildInvoke(LLVMBuilderRef param0, LLVMValueRef Fn, LLVMValueRef[] Args, LLVMBasicBlockRef Then, LLVMBasicBlockRef Catch, string Name)
         {
             if (Args.Length == 0)
             {
@@ -203,8 +285,7 @@
             return BuildGEP(B, Pointer, out Indices[0], (uint)Indices.Length, Name);
         }
 
-        public static LLVMValueRef BuildInBoundsGEP(LLVMBuilderRef B, LLVMValueRef Pointer, LLVMValueRef[] Indices,
-            string Name)
+        public static LLVMValueRef BuildInBoundsGEP(LLVMBuilderRef B, LLVMValueRef Pointer, LLVMValueRef[] Indices, string Name)
         {
             if (Indices.Length == 0)
             {
@@ -213,6 +294,51 @@
             }
 
             return BuildInBoundsGEP(B, Pointer, out Indices[0], (uint)Indices.Length, Name);
+        }
+
+        public static LLVMValueRef BuildCall(LLVMBuilderRef param0, LLVMValueRef Fn, LLVMValueRef[] Args, string Name)
+        {
+            if (Args.Length == 0)
+            {
+                LLVMValueRef dummy;
+                return BuildCall(param0, Fn, out dummy, 0, Name);
+            }
+
+            return BuildCall(param0, Fn, out Args[0], (uint)Args.Length, Name);
+        }
+
+        public static void InitializeMCJITCompilerOptions(LLVMMCJITCompilerOptions[] Options)
+        {
+            if (Options.Length == 0)
+            {
+                LLVMMCJITCompilerOptions dummy;
+                InitializeMCJITCompilerOptions(out dummy, 0);
+                return;
+            }
+
+            InitializeMCJITCompilerOptions(out Options[0], Options.Length);
+        }
+
+        public static LLVMBool CreateMCJITCompilerForModule(out LLVMExecutionEngineRef OutJIT, LLVMModuleRef M, LLVMMCJITCompilerOptions[] Options, out IntPtr OutError)
+        {
+            if (Options.Length == 0)
+            {
+                LLVMMCJITCompilerOptions dummy;
+                return CreateMCJITCompilerForModule(out OutJIT, M, out dummy, 0, out OutError);
+            }
+
+            return CreateMCJITCompilerForModule(out OutJIT, M, out Options[0], Options.Length, out OutError);
+        }
+
+        public static LLVMGenericValueRef RunFunction(LLVMExecutionEngineRef EE, LLVMValueRef F, LLVMGenericValueRef[] Args)
+        {
+            if (Args.Length == 0)
+            {
+                LLVMGenericValueRef dummy;
+                return RunFunction(EE, F, 0, out dummy);
+            }
+
+            return RunFunction(EE, F, (uint)Args.Length, out Args[0]);
         }
     }
 }

--- a/Values/BasicBlock.cs
+++ b/Values/BasicBlock.cs
@@ -54,5 +54,10 @@
 
             return bb;
         }
+
+        public static implicit operator LLVMBasicBlockRef(BasicBlock basicBlock)
+        {
+            return LLVM.ValueAsBasicBlock(basicBlock.value);
+        }
     }
 }


### PR DESCRIPTION
Suggesting to use the new OOP API types in the IRBuilder method signatures now that we can, instead of exposing the structs of the C API. Also, using `bool` instead of `LLVMBool` in the same signatures.