### PR TITLE
Added value equality checks for the C API structs.

### DIFF
--- a/LLVMBasicBlockRef.cs
+++ b/LLVMBasicBlockRef.cs
@@ -1,6 +1,8 @@
 ﻿namespace LLVMSharp
 {
-    partial struct LLVMBasicBlockRef
+    using System;
+
+    partial struct LLVMBasicBlockRef : IEquatable<LLVMBasicBlockRef>
     {
         public LLVMValueRef BasicBlockAsValue()
         {
@@ -60,6 +62,38 @@
         public LLVMValueRef GetLastInstruction()
         {
             return LLVM.GetLastInstruction(this);
+        }
+
+        public bool Equals(LLVMBasicBlockRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMBasicBlockRef)
+            {
+                return this.Equals((LLVMBasicBlockRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMBasicBlockRef op1, LLVMBasicBlockRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMBasicBlockRef op1, LLVMBasicBlockRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
         }
     }
 }

--- a/LLVMBuilderRef.cs
+++ b/LLVMBuilderRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMBuilderRef : IEquatable<LLVMBuilderRef>
+    {
+        public bool Equals(LLVMBuilderRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMBuilderRef)
+            {
+                return this.Equals((LLVMBuilderRef) obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMBuilderRef op1, LLVMBuilderRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMBuilderRef op1, LLVMBuilderRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMContextRef.cs
+++ b/LLVMContextRef.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    partial struct LLVMContextRef
+    partial struct LLVMContextRef : IEquatable<LLVMContextRef>
     {
         public void ContextDispose()
         {
@@ -162,6 +162,38 @@
         public LLVMBool ParseIRInContext(LLVMMemoryBufferRef @MemBuf, out LLVMModuleRef @OutM, out IntPtr @OutMessage)
         {
             return LLVM.ParseIRInContext(this, @MemBuf, out @OutM, out @OutMessage);
+        }
+
+        public bool Equals(LLVMContextRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMContextRef) 
+            {
+                return this.Equals((LLVMContextRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMContextRef op1, LLVMContextRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMContextRef op1, LLVMContextRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
         }
     }
 }

--- a/LLVMDiagnosticInfoRef.cs
+++ b/LLVMDiagnosticInfoRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMDiagnosticInfoRef : IEquatable<LLVMDiagnosticInfoRef>
+    {
+        public bool Equals(LLVMDiagnosticInfoRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMDiagnosticInfoRef)
+            {
+                return this.Equals((LLVMDiagnosticInfoRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMDiagnosticInfoRef op1, LLVMDiagnosticInfoRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMDiagnosticInfoRef op1, LLVMDiagnosticInfoRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMDisasmContextRef.cs
+++ b/LLVMDisasmContextRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMDisasmContextRef : IEquatable<LLVMDisasmContextRef>
+    {
+        public bool Equals(LLVMDisasmContextRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMDisasmContextRef)
+            {
+                return this.Equals((LLVMDisasmContextRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMDisasmContextRef op1, LLVMDisasmContextRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMDisasmContextRef op1, LLVMDisasmContextRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMExecutionEngineRef.cs
+++ b/LLVMExecutionEngineRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMExecutionEngineRef : IEquatable<LLVMExecutionEngineRef>
+    {
+        public bool Equals(LLVMExecutionEngineRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMExecutionEngineRef)
+            {
+                return this.Equals((LLVMExecutionEngineRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMExecutionEngineRef op1, LLVMExecutionEngineRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMExecutionEngineRef op1, LLVMExecutionEngineRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMGenericValueRef.cs
+++ b/LLVMGenericValueRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMGenericValueRef : IEquatable<LLVMGenericValueRef>
+    {
+        public bool Equals(LLVMGenericValueRef other)
+        {
+            return this.Equals(other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMGenericValueRef)
+            {
+                return this.Equals((LLVMGenericValueRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMGenericValueRef op1, LLVMGenericValueRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMGenericValueRef op1, LLVMGenericValueRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMMCJITMemoryManagerRef.cs
+++ b/LLVMMCJITMemoryManagerRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMMCJITMemoryManagerRef : IEquatable<LLVMMCJITMemoryManagerRef>
+    {
+        public bool Equals(LLVMMCJITMemoryManagerRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMMCJITMemoryManagerRef)
+            {
+                return this.Equals((LLVMMCJITMemoryManagerRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMMCJITMemoryManagerRef op1, LLVMMCJITMemoryManagerRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMMCJITMemoryManagerRef op1, LLVMMCJITMemoryManagerRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMMemoryBufferRef.cs
+++ b/LLVMMemoryBufferRef.cs
@@ -1,0 +1,40 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMMemoryBufferRef : IEquatable<LLVMMemoryBufferRef>
+    {
+
+        public bool Equals(LLVMMemoryBufferRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMMemoryBufferRef)
+            {
+                return this.Equals((LLVMMemoryBufferRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMMemoryBufferRef op1, LLVMMemoryBufferRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMMemoryBufferRef op1, LLVMMemoryBufferRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMModuleProviderRef.cs
+++ b/LLVMModuleProviderRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMModuleProviderRef : IEquatable<LLVMModuleProviderRef>
+    {
+        public bool Equals(LLVMModuleProviderRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMModuleProviderRef)
+            {
+                return this.Equals((LLVMModuleProviderRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMModuleProviderRef op1, LLVMModuleProviderRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMModuleProviderRef op1, LLVMModuleProviderRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMModuleRef.cs
+++ b/LLVMModuleRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMModuleRef : IEquatable<LLVMModuleRef>
+    {
+        public bool Equals(LLVMModuleRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMModuleRef)
+            {
+                return this.Equals((LLVMModuleRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMModuleRef op1, LLVMModuleRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMModuleRef op1, LLVMModuleRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMObjectFileRef.cs
+++ b/LLVMObjectFileRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMObjectFileRef : IEquatable<LLVMObjectFileRef>
+    {
+        public bool Equals(LLVMObjectFileRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMObjectFileRef)
+            {
+                return this.Equals((LLVMObjectFileRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMObjectFileRef op1, LLVMObjectFileRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMObjectFileRef op1, LLVMObjectFileRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMPassManagerBuilderRef.cs
+++ b/LLVMPassManagerBuilderRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMPassManagerBuilderRef : IEquatable<LLVMPassManagerBuilderRef>
+    {
+        public bool Equals(LLVMPassManagerBuilderRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMPassManagerBuilderRef)
+            {
+                return this.Equals((LLVMPassManagerBuilderRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMPassManagerBuilderRef op1, LLVMPassManagerBuilderRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMPassManagerBuilderRef op1, LLVMPassManagerBuilderRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMPassManagerRef.cs
+++ b/LLVMPassManagerRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMPassManagerRef : IEquatable<LLVMPassManagerRef>
+    {
+        public bool Equals(LLVMPassManagerRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMPassManagerRef)
+            {
+                return this.Equals((LLVMPassManagerRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMPassManagerRef op1, LLVMPassManagerRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMPassManagerRef op1, LLVMPassManagerRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMPassRegistryRef.cs
+++ b/LLVMPassRegistryRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMPassRegistryRef : IEquatable<LLVMPassRegistryRef>
+    {
+        public bool Equals(LLVMPassRegistryRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMPassRegistryRef)
+            {
+                return this.Equals((LLVMPassRegistryRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMPassRegistryRef op1, LLVMPassRegistryRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMPassRegistryRef op1, LLVMPassRegistryRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMRelocationIteratorRef.cs
+++ b/LLVMRelocationIteratorRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMRelocationIteratorRef : IEquatable<LLVMRelocationIteratorRef>
+    {
+        public bool Equals(LLVMRelocationIteratorRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMRelocationIteratorRef)
+            {
+                return this.Equals((LLVMRelocationIteratorRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMRelocationIteratorRef op1, LLVMRelocationIteratorRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMRelocationIteratorRef op1, LLVMRelocationIteratorRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMSectionIteratorRef.cs
+++ b/LLVMSectionIteratorRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMSectionIteratorRef : IEquatable<LLVMSectionIteratorRef>
+    {
+        public bool Equals(LLVMSectionIteratorRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMSectionIteratorRef)
+            {
+                return this.Equals((LLVMSectionIteratorRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMSectionIteratorRef op1, LLVMSectionIteratorRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMSectionIteratorRef op1, LLVMSectionIteratorRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMSharp.csproj
+++ b/LLVMSharp.csproj
@@ -32,7 +32,32 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LLVMBuilderRef.cs" />
+    <Compile Include="LLVMDiagnosticInfoRef.cs" />
+    <Compile Include="LLVMDisasmContextRef.cs" />
+    <Compile Include="LLVMExecutionEngineRef.cs" />
+    <Compile Include="LLVMGenericValueRef.cs" />
+    <Compile Include="LLVMMCJITMemoryManagerRef.cs" />
+    <Compile Include="LLVMMemoryBufferRef.cs" />
     <Compile Include="Conversions.cs" />
+    <Compile Include="LLVMModuleProviderRef.cs" />
+    <Compile Include="LLVMModuleRef.cs" />
+    <Compile Include="LLVMObjectFileRef.cs" />
+    <Compile Include="LLVMPassManagerBuilderRef.cs" />
+    <Compile Include="LLVMPassManagerRef.cs" />
+    <Compile Include="LLVMPassRegistryRef.cs" />
+    <Compile Include="LLVMRelocationIteratorRef.cs" />
+    <Compile Include="LLVMSectionIteratorRef.cs" />
+    <Compile Include="LLVMSymbolIteratorRef.cs" />
+    <Compile Include="LLVMTargetDataRef.cs" />
+    <Compile Include="LLVMTargetLibraryInfoRef.cs" />
+    <Compile Include="LLVMTargetMachineRef.cs" />
+    <Compile Include="LLVMTargetRef.cs" />
+    <Compile Include="LLVMUseRef.cs" />
+    <Compile Include="llvm_lto_t.cs" />
+    <Compile Include="lto_bool_t.cs" />
+    <Compile Include="lto_code_gen_t.cs" />
+    <Compile Include="lto_module_t.cs" />
     <Compile Include="Values\Instructions\AtomicCmpXchgInst.cs" />
     <Compile Include="Values\Instructions\AtomicRMWInst.cs" />
     <Compile Include="Values\Instructions\BinaryOperator.cs" />

--- a/LLVMSymbolIteratorRef.cs
+++ b/LLVMSymbolIteratorRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMSymbolIteratorRef : IEquatable<LLVMSymbolIteratorRef>
+    {
+        public bool Equals(LLVMSymbolIteratorRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMSymbolIteratorRef)
+            {
+                return this.Equals((LLVMSymbolIteratorRef)obj);
+            }
+            else
+            {
+                return false;
+            }  
+        }
+
+        public static bool operator ==(LLVMSymbolIteratorRef op1, LLVMSymbolIteratorRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMSymbolIteratorRef op1, LLVMSymbolIteratorRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMTargetDataRef.cs
+++ b/LLVMTargetDataRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMTargetDataRef : IEquatable<LLVMTargetDataRef>
+    {
+        public bool Equals(LLVMTargetDataRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMTargetDataRef)
+            {
+                return this.Equals((LLVMTargetDataRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMTargetDataRef op1, LLVMTargetDataRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMTargetDataRef op1, LLVMTargetDataRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMTargetLibraryInfoRef.cs
+++ b/LLVMTargetLibraryInfoRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMTargetLibraryInfoRef : IEquatable<LLVMTargetLibraryInfoRef>
+    {
+        public bool Equals(LLVMTargetLibraryInfoRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMTargetLibraryInfoRef)
+            {
+                return this.Equals((LLVMTargetLibraryInfoRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMTargetLibraryInfoRef op1, LLVMTargetLibraryInfoRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMTargetLibraryInfoRef op1, LLVMTargetLibraryInfoRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMTargetMachineRef.cs
+++ b/LLVMTargetMachineRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMTargetMachineRef : IEquatable<LLVMTargetMachineRef>
+    {
+        public bool Equals(LLVMTargetMachineRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMTargetMachineRef)
+            {
+                return this.Equals((LLVMTargetMachineRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator==(LLVMTargetMachineRef op1, LLVMTargetMachineRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMTargetMachineRef op1, LLVMTargetMachineRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMTargetRef.cs
+++ b/LLVMTargetRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMTargetRef : IEquatable<LLVMTargetRef>
+    {
+        public bool Equals(LLVMTargetRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMTargetRef)
+            {
+                return this.Equals((LLVMTargetRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMTargetRef op1, LLVMTargetRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMTargetRef op1, LLVMTargetRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMTypeRef.cs
+++ b/LLVMTypeRef.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    partial struct LLVMTypeRef
+    partial struct LLVMTypeRef : IEquatable<LLVMTypeRef>
     {
         public static LLVMTypeRef FunctionType(LLVMTypeRef returnType, LLVMTypeRef[] @ParamTypes, LLVMBool @IsVarArg)
         {
@@ -397,6 +397,38 @@
         public double GenericValueToFloat(LLVMGenericValueRef @GenVal)
         {
             return LLVM.GenericValueToFloat(this, @GenVal);
+        }
+
+        public bool Equals(LLVMTypeRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMTypeRef)
+            {
+                return this.Equals((LLVMTypeRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMTypeRef op1, LLVMTypeRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMTypeRef op1, LLVMTypeRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
         }
     }
 }

--- a/LLVMUseRef.cs
+++ b/LLVMUseRef.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct LLVMUseRef : IEquatable<LLVMUseRef>
+    {
+        public bool Equals(LLVMUseRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMUseRef)
+            {
+                return this.Equals((LLVMUseRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMUseRef op1, LLVMUseRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMUseRef op1, LLVMUseRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/LLVMValueRef.cs
+++ b/LLVMValueRef.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Runtime.InteropServices;
 
-    partial struct LLVMValueRef
+    partial struct LLVMValueRef : IEquatable<LLVMValueRef>
     {
         public override string ToString()
         {
@@ -1291,6 +1291,38 @@
         public void ViewFunctionCFGOnly()
         {
             LLVM.ViewFunctionCFGOnly(this);
+        }
+
+        public bool Equals(LLVMValueRef other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is LLVMValueRef)
+            {
+                return this.Equals((LLVMValueRef)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(LLVMValueRef op1, LLVMValueRef op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(LLVMValueRef op1, LLVMValueRef op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
         }
     }
 }

--- a/llvm_lto_t.cs
+++ b/llvm_lto_t.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct llvm_lto_t : IEquatable<llvm_lto_t>
+    {
+        public bool Equals(llvm_lto_t other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is llvm_lto_t)
+            {
+                return this.Equals((llvm_lto_t)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(llvm_lto_t op1, llvm_lto_t op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(llvm_lto_t op1, llvm_lto_t op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/lto_bool_t.cs
+++ b/lto_bool_t.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct lto_bool_t : IEquatable<lto_bool_t>
+    {
+        public bool Equals(lto_bool_t other)
+        {
+            return this.Value == other.Value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is lto_bool_t)
+            {
+                return this.Equals((lto_bool_t)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(lto_bool_t op1, lto_bool_t op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(lto_bool_t op1, lto_bool_t op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Value.GetHashCode();
+        }
+    }
+}

--- a/lto_code_gen_t.cs
+++ b/lto_code_gen_t.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct lto_code_gen_t : IEquatable<lto_code_gen_t>
+    {
+        public bool Equals(lto_code_gen_t other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is lto_code_gen_t)
+            {
+                return this.Equals((lto_code_gen_t)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(lto_code_gen_t op1, lto_code_gen_t op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(lto_code_gen_t op1, lto_code_gen_t op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}

--- a/lto_module_t.cs
+++ b/lto_module_t.cs
@@ -1,0 +1,39 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    public partial struct lto_module_t : IEquatable<lto_module_t>
+    {
+        public bool Equals(lto_module_t other)
+        {
+            return this.Pointer == other.Pointer;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is lto_module_t)
+            {
+                return this.Equals((lto_module_t)obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool operator ==(lto_module_t op1, lto_module_t op2)
+        {
+            return op1.Equals(op2);
+        }
+
+        public static bool operator !=(lto_module_t op1, lto_module_t op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Pointer.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
For each struct from the C API, I've done the following:

- Implemented `IEquatable<T>`
- Overridden `Equals(object)` to use the specialized equality comparison
- Overridden `GetHashCode()`
- Added operators `==` and `!=`, which use the specialized equality comparison