### PR TITLE
Added value equality comparisons for OOP API classes.

### DIFF
--- a/ExecutionEngine.cs
+++ b/ExecutionEngine.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Runtime.InteropServices;
 
-    public sealed class ExecutionEngine : IDisposable
+    public sealed class ExecutionEngine : IDisposable, IEquatable<ExecutionEngine>
     {
         private readonly LLVMExecutionEngineRef instance;
         
@@ -165,6 +165,45 @@
             string errormessage = Marshal.PtrToStringAnsi(error);
             LLVM.DisposeMessage(error);
             throw new Exception(errormessage);
+        }
+
+        public bool Equals(ExecutionEngine other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.instance == other.instance;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as ExecutionEngine);
+        }
+
+        public static bool operator ==(ExecutionEngine op1, ExecutionEngine op2)
+        {
+            if (ReferenceEquals(op1, null))
+            {
+                return ReferenceEquals(op2, null);
+            }
+            else
+            {
+                return op1.Equals(op2);
+            }
+        }
+
+        public static bool operator !=(ExecutionEngine op1, ExecutionEngine op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.instance.GetHashCode();
         }
     }
 }

--- a/IRBuilder.cs
+++ b/IRBuilder.cs
@@ -2,7 +2,7 @@ namespace LLVMSharp
 {
     using System;
 
-    public sealed class IRBuilder : IDisposable
+    public sealed class IRBuilder : IDisposable, IEquatable<IRBuilder>
     {
         private readonly LLVMBuilderRef instance;
 
@@ -543,6 +543,45 @@ namespace LLVMSharp
         public AtomicRMWInst CreateAtomicRMW(LLVMAtomicRMWBinOp @op, Value @PTR, Value @Val, LLVMAtomicOrdering @ordering, LLVMBool @singleThread)
         {
             return new AtomicRMWInst(LLVM.BuildAtomicRMW(this.instance, @op, @PTR, @Val, @ordering, @singleThread));
+        }
+
+        public bool Equals(IRBuilder other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.instance == other.instance;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as IRBuilder);
+        }
+
+        public static bool operator ==(IRBuilder op1, IRBuilder op2)
+        {
+            if (ReferenceEquals(op1, null))
+            {
+                return ReferenceEquals(op2, null);
+            }
+            else
+            {
+                return op1.Equals(op2);
+            }
+        }
+
+        public static bool operator !=(IRBuilder op1, IRBuilder op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.instance.GetHashCode();
         }
     }
 }

--- a/LLVMContext.cs
+++ b/LLVMContext.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class LLVMContext
+    public sealed class LLVMContext : IEquatable<LLVMContext>
     {
         private readonly LLVMContextRef innerRef;
 
@@ -31,6 +31,45 @@
         public void SetYieldCallBack(LLVMYieldCallback callback, IntPtr opaqueHande)
         {
             LLVM.ContextSetYieldCallback(this.innerRef, callback, opaqueHande);
+        }
+
+        public bool Equals(LLVMContext other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.innerRef == other.innerRef;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as LLVMContext);
+        }
+
+        public static bool operator ==(LLVMContext op1, LLVMContext op2)
+        {
+            if (ReferenceEquals(op1, null))
+            {
+                return ReferenceEquals(op2, null);
+            }
+            else
+            {
+                return op1.Equals(op2);
+            }
+        }
+
+        public static bool operator !=(LLVMContext op1, LLVMContext op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.innerRef.GetHashCode();
         }
     }
 }

--- a/Module.cs
+++ b/Module.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Runtime.InteropServices;
 
-    public sealed class Module
+    public sealed class Module : IEquatable<Module>
     {
         public string DataLayout
         {
@@ -180,6 +180,45 @@
         public bool LinkModules(Module @Src, uint @Unused, out IntPtr @OutMessage)
         {
             return LLVM.LinkModules(this.instance, @Src, @Unused, out @OutMessage);
+        }
+
+        public bool Equals(Module other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.instance == other.instance;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as Module);
+        }
+
+        public static bool operator ==(Module op1, Module op2)
+        {
+            if (ReferenceEquals(op1, null))
+            {
+                return ReferenceEquals(op2, null);
+            }
+            else
+            {
+                return op1.Equals(op2);
+            }
+        }
+
+        public static bool operator !=(Module op1, Module op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.instance.GetHashCode();
         }
     }
 }

--- a/PassManager.cs
+++ b/PassManager.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class PassManager : IDisposable
+    public sealed class PassManager : IDisposable, IEquatable<PassManager>
     {
         private readonly LLVMPassManagerRef instance;
 
@@ -333,6 +333,45 @@
         public void AddSLPVectorizePass()
         {
             LLVM.AddSLPVectorizePass(this.instance);
+        }
+
+        public bool Equals(PassManager other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.instance == other.instance;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as PassManager);
+        }
+
+        public static bool operator ==(PassManager op1, PassManager op2)
+        {
+            if (ReferenceEquals(op1, null))
+            {
+                return ReferenceEquals(op2, null);
+            }
+            else
+            {
+                return op1.Equals(op2);
+            }
+        }
+
+        public static bool operator !=(PassManager op1, PassManager op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.instance.GetHashCode();
         }
     }
 }

--- a/Type.cs
+++ b/Type.cs
@@ -1,6 +1,8 @@
 ﻿namespace LLVMSharp
 {
-    public class Type
+    using System;
+
+    public class Type : IEquatable<Type>
     {
         protected readonly LLVMTypeRef instance;
 
@@ -174,6 +176,45 @@
         public static Type LabelType(LLVMContext c)
         {
             return new Type(LLVM.LabelTypeInContext(c.InternalValue));
+        }
+
+        public bool Equals(Type other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.instance == other.instance;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as Type);
+        }
+
+        public static bool operator ==(Type op1, Type op2)
+        {
+            if (ReferenceEquals(op1, null))
+            {
+                return ReferenceEquals(op2, null);
+            }
+            else
+            {
+                return op1.Equals(op2);
+            }
+        }
+
+        public static bool operator !=(Type op1, Type op2)
+        {
+            return !(op1 == op2);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.instance.GetHashCode();
         }
     }
 }

--- a/Value.cs
+++ b/Value.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Runtime.InteropServices;
 
-    public abstract class Value
+    public abstract class Value : IEquatable<Value>
     {
         internal static Value[] FromArray(LLVMValueRef[] source)
         {
@@ -64,40 +64,45 @@
             return retVal ?? string.Empty;
         }
 
-        public override int GetHashCode()
+        
+        public bool Equals(Value other)
         {
-            return (int)this.value.GetHashCode();
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            else
+            {
+                return this.value == other.value;
+            }
         }
 
         public override bool Equals(object obj)
         {
-            Value other = obj as Value;
-            if (other == null)
-            {
-                return false;
-            }
-
-            return other == this;
+            return this.Equals(obj as Value);
         }
 
-        public static bool operator ==(Value l, Value r)
+        public static bool operator ==(Value op1, Value op2)
         {
-            if (l == null || r == null)
+            if (ReferenceEquals(op1, null))
             {
-                return false;
+                return ReferenceEquals(op2, null);
             }
-
-            return l.value.Pointer == r.value.Pointer;
+            else
+            {
+                return op1.Equals(op2);
+            }
         }
 
-        public static bool operator !=(Value l, Value r)
+        public static bool operator !=(Value op1, Value op2)
         {
-            if (l == null || r == null)
-            {
-                return false;
-            }
-
-            return l.value.Pointer != r.value.Pointer;
+            return !(op1 == op2);
         }
+
+        public override int GetHashCode()
+        {
+            return this.value.GetHashCode();
+        }
+
     }
 }


### PR DESCRIPTION
I have followed the following pattern:

- Implemented the `Equals(T)` method (required by `IEquatable<T>`), which also handles the case where the argument is `null`. The comparison logic is entirely in this method and not repeated elsewhere.
- Overridden the `Equals(object)` method to call the `Equals(T)` method (uses `as`, doesn't check for `null`, because the callee checks it).
- Provided operator `==` that checks at least one operand for `null` and then calls the `Equals(T)` method (which checks the other operand for `null` and then performs the comparison).
- Provided operator `!=` as a negation of `==`.
- Provided override of `GetHashCode()`.
- Used `ReferenceEquals` for all `null` checks, to avoid accidental recursion in equality methods and operators.
- Every operand is checked for `null` exactly once (including the built-in CLR check for instance methods), in every code path visible to the user.