### PR TITLE
Removed InitializeMCJITCompilerOptions overload.

### DIFF
--- a/Overloads.cs
+++ b/Overloads.cs
@@ -305,18 +305,6 @@
             return BuildCall(param0, fn, out args[0], (uint)args.Length, name);
         }
 
-        public static void InitializeMCJITCompilerOptions(LLVMMCJITCompilerOptions[] options)
-        {
-            if (options.Length == 0)
-            {
-                LLVMMCJITCompilerOptions dummy;
-                InitializeMCJITCompilerOptions(out dummy, 0);
-                return;
-            }
-
-            InitializeMCJITCompilerOptions(out options[0], options.Length);
-        }
-
         public static LLVMGenericValueRef RunFunction(LLVMExecutionEngineRef ee, LLVMValueRef f, LLVMGenericValueRef[] args)
         {
             if (args.Length == 0)


### PR DESCRIPTION
Removed this:

    void InitializeMCJITCompilerOptions(LLVMMCJITCompilerOptions[] options)

...because it implies that `LLVMMCJITCompilerOptions` is meant to be used in an array (with `sizeOfOptions` being the length of the array, thus omitted in this overload). In fact, the size parameter is meant to provide the option to initialize a single instance of this struct, fully or partially.