### PR TITLE
MakeHandleOwner() is now in its own interface, implemented only by IDisposable wrapper types.

### DIFF
--- a/Context.cs
+++ b/Context.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class Context : IEquatable<Context>, IDisposable, IWrapper<LLVMContextRef>
+    public sealed class Context : IEquatable<Context>, IDisposable, IDisposableWrapper<LLVMContextRef>
     {
         public static Context Global
         {
@@ -94,7 +94,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMContextRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMContextRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/ConversionUtilities.cs
+++ b/ConversionUtilities.cs
@@ -49,7 +49,7 @@
         }
 
         public static TWrapper MakeHandleOwner<TWrapper, THandle>(this TWrapper wrapper)
-            where TWrapper : class, IWrapper<THandle>
+            where TWrapper : class, IDisposableWrapper<THandle>
             where THandle : struct
         {
             wrapper.MakeHandleOwner();

--- a/DiagnosticInfo.cs
+++ b/DiagnosticInfo.cs
@@ -9,10 +9,6 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMDiagnosticInfoRef>.MakeHandleOwner()
-        {
-        }
-
         private readonly LLVMDiagnosticInfoRef _instance;
 
         internal DiagnosticInfo(LLVMDiagnosticInfoRef instance)

--- a/DisasmContext.cs
+++ b/DisasmContext.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class DisasmContext : IWrapper<LLVMDisasmContextRef>, IDisposable
+    public sealed class DisasmContext : IDisposableWrapper<LLVMDisasmContextRef>, IDisposable
     {
         public static DisasmContext CreateDisasm(string tripleName, IntPtr disInfo, int tagType, LLVMOpInfoCallback getOpInfo,
                                            LLVMSymbolLookupCallback symbolLookUp)
@@ -36,7 +36,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMDisasmContextRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMDisasmContextRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/ExecutionEngine.cs
+++ b/ExecutionEngine.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    public sealed class ExecutionEngine : IDisposable, IEquatable<ExecutionEngine>, IWrapper<LLVMExecutionEngineRef>
+    public sealed class ExecutionEngine : IDisposable, IEquatable<ExecutionEngine>, IDisposableWrapper<LLVMExecutionEngineRef>
     {
         LLVMExecutionEngineRef IWrapper<LLVMExecutionEngineRef>.ToHandleType()
         {
             return this._instance;
         }
 
-        void IWrapper<LLVMExecutionEngineRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMExecutionEngineRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/GenericValue.cs
+++ b/GenericValue.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class GenericValue : IWrapper<LLVMGenericValueRef>, IDisposable
+    public sealed class GenericValue : IDisposableWrapper<LLVMGenericValueRef>, IDisposable
     {
         public static GenericValue CreateGenericValueOfInt(Type t, ulong n, bool isSigned)
         {
@@ -30,7 +30,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMGenericValueRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMGenericValueRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/IDisposableWrapper.cs
+++ b/IDisposableWrapper.cs
@@ -1,0 +1,10 @@
+﻿namespace LLVMSharp
+{
+    using System;
+
+    internal interface IDisposableWrapper<THandle> : IWrapper<THandle>, IDisposable
+        where THandle : struct
+    {
+        void MakeHandleOwner();
+    }
+}

--- a/IRBuilder.cs
+++ b/IRBuilder.cs
@@ -2,7 +2,7 @@ namespace LLVMSharp
 {
     using System;
 
-    public sealed class IRBuilder : IDisposable, IEquatable<IRBuilder>, IWrapper<LLVMBuilderRef>
+    public sealed class IRBuilder : IDisposable, IEquatable<IRBuilder>, IDisposableWrapper<LLVMBuilderRef>
     {
         public static IRBuilder Create()
         {
@@ -19,7 +19,7 @@ namespace LLVMSharp
             return this._instance;
         }
 
-        void IWrapper<LLVMBuilderRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMBuilderRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/IWrapper.cs
+++ b/IWrapper.cs
@@ -4,6 +4,5 @@
         where THandle : struct 
     {
         THandle ToHandleType();
-        void MakeHandleOwner();
     }
 }

--- a/LLVMSharp.csproj
+++ b/LLVMSharp.csproj
@@ -74,6 +74,7 @@
     <Compile Include="DisasmContext.cs" />
     <Compile Include="ErrorUtilities.cs" />
     <Compile Include="GenericValue.cs" />
+    <Compile Include="IDisposableWrapper.cs" />
     <Compile Include="IHandle.cs" />
     <Compile Include="IWrapper.cs" />
     <Compile Include="LinkageExtensions.cs" />

--- a/MCJITMemoryManager.cs
+++ b/MCJITMemoryManager.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class MCJITMemoryManager : IWrapper<LLVMMCJITMemoryManagerRef>, IDisposable
+    public sealed class MCJITMemoryManager : IDisposableWrapper<LLVMMCJITMemoryManagerRef>, IDisposable
     {
         public static MCJITMemoryManager Create(IntPtr opaque, LLVMMemoryManagerAllocateCodeSectionCallback allocateCodeSection, LLVMMemoryManagerAllocateDataSectionCallback allocateDataSection, LLVMMemoryManagerFinalizeMemoryCallback finalizeMemory, LLVMMemoryManagerDestroyCallback destroy)
         {
@@ -15,7 +15,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMMCJITMemoryManagerRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMMCJITMemoryManagerRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/MemoryBuffer.cs
+++ b/MemoryBuffer.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Runtime.InteropServices;
 
-    public sealed class MemoryBuffer : IWrapper<LLVMMemoryBufferRef>, IDisposable
+    public sealed class MemoryBuffer : IDisposableWrapper<LLVMMemoryBufferRef>, IDisposable
     {
         public static MemoryBuffer CreateMemoryBufferWithContentsOfFile(string path)
         {
@@ -48,7 +48,7 @@
 
         LLVMMemoryBufferRef IWrapper<LLVMMemoryBufferRef>.ToHandleType() => this._instance;
 
-        void IWrapper<LLVMMemoryBufferRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMMemoryBufferRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/Module.cs
+++ b/Module.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Runtime.InteropServices;
 
-    public sealed class Module : IEquatable<Module>, IDisposable, IWrapper<LLVMModuleRef>
+    public sealed class Module : IEquatable<Module>, IDisposable, IDisposableWrapper<LLVMModuleRef>
     {
         public static Module Create(string moduleId)
         {
@@ -23,7 +23,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMModuleRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMModuleRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/ModuleProvider.cs
+++ b/ModuleProvider.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    public sealed class ModuleProvider : IWrapper<LLVMModuleProviderRef>, IDisposable
+    public sealed class ModuleProvider : IDisposableWrapper<LLVMModuleProviderRef>, IDisposable
     {
         LLVMModuleProviderRef IWrapper<LLVMModuleProviderRef>.ToHandleType()
         {
             return this._instance;
         }
 
-        void IWrapper<LLVMModuleProviderRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMModuleProviderRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/ObjectFile.cs
+++ b/ObjectFile.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class ObjectFile : IWrapper<LLVMObjectFileRef>, IDisposable
+    public sealed class ObjectFile : IDisposableWrapper<LLVMObjectFileRef>, IDisposable
     {
         public static ObjectFile Create(MemoryBuffer memBuf)
         {
@@ -14,7 +14,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMObjectFileRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMObjectFileRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/PassManager.cs
+++ b/PassManager.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class PassManager : IDisposable, IEquatable<PassManager>, IWrapper<LLVMPassManagerRef>
+    public sealed class PassManager : IDisposable, IEquatable<PassManager>, IDisposableWrapper<LLVMPassManagerRef>
     {
         public static PassManager Create()
         {
@@ -30,7 +30,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMPassManagerRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMPassManagerRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/PassManagerBuilder.cs
+++ b/PassManagerBuilder.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class PassManagerBuilder : IWrapper<LLVMPassManagerBuilderRef>, IDisposable
+    public sealed class PassManagerBuilder : IDisposableWrapper<LLVMPassManagerBuilderRef>, IDisposable
     {
         public static PassManagerBuilder Create()
         {
@@ -15,7 +15,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMPassManagerBuilderRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMPassManagerBuilderRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/PassRegistry.cs
+++ b/PassRegistry.cs
@@ -11,11 +11,7 @@
         {
             return this._instance;
         }
-
-        void IWrapper<LLVMPassRegistryRef>.MakeHandleOwner()
-        {
-        }
-
+        
         private readonly LLVMPassRegistryRef _instance;
 
         internal PassRegistry(LLVMPassRegistryRef instance)

--- a/RelocationIterator.cs
+++ b/RelocationIterator.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    public sealed class RelocationIterator : IWrapper<LLVMRelocationIteratorRef>, IDisposable
+    public sealed class RelocationIterator : IDisposableWrapper<LLVMRelocationIteratorRef>, IDisposable
     {
         LLVMRelocationIteratorRef IWrapper<LLVMRelocationIteratorRef>.ToHandleType()
         {
             return this._instance;
         }
 
-        void IWrapper<LLVMRelocationIteratorRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMRelocationIteratorRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/SectionIterator.cs
+++ b/SectionIterator.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    public sealed class SectionIterator : IWrapper<LLVMSectionIteratorRef>, IDisposable
+    public sealed class SectionIterator : IDisposableWrapper<LLVMSectionIteratorRef>, IDisposable
     {
         LLVMSectionIteratorRef IWrapper<LLVMSectionIteratorRef>.ToHandleType()
         {
             return this._instance;
         }
 
-        void IWrapper<LLVMSectionIteratorRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMSectionIteratorRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/SymbolIterator.cs
+++ b/SymbolIterator.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    public sealed class SymbolIterator : IWrapper<LLVMSymbolIteratorRef>, IDisposable
+    public sealed class SymbolIterator : IDisposableWrapper<LLVMSymbolIteratorRef>, IDisposable
     {
         LLVMSymbolIteratorRef IWrapper<LLVMSymbolIteratorRef>.ToHandleType()
         {
             return this._instance;
         }
 
-        void IWrapper<LLVMSymbolIteratorRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMSymbolIteratorRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/Target.cs
+++ b/Target.cs
@@ -27,10 +27,6 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMTargetRef>.MakeHandleOwner()
-        {
-        }
-
         private readonly LLVMTargetRef _instance;
 
         internal Target(LLVMTargetRef instance)

--- a/TargetData.cs
+++ b/TargetData.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public sealed class TargetData : IWrapper<LLVMTargetDataRef>, IDisposable
+    public sealed class TargetData : IDisposableWrapper<LLVMTargetDataRef>, IDisposable
     {
         public static TargetData Create(string stringRep)
         {
@@ -14,7 +14,7 @@
             return this._instance;
         }
 
-        void IWrapper<LLVMTargetDataRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMTargetDataRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/TargetLibraryInfo.cs
+++ b/TargetLibraryInfo.cs
@@ -6,11 +6,7 @@
         {
             return this._instance;
         }
-
-        void IWrapper<LLVMTargetLibraryInfoRef>.MakeHandleOwner()
-        {
-        }
-
+        
         private readonly LLVMTargetLibraryInfoRef _instance;
 
         internal TargetLibraryInfo(LLVMTargetLibraryInfoRef instance)

--- a/TargetMachine.cs
+++ b/TargetMachine.cs
@@ -2,14 +2,14 @@
 {
     using System;
 
-    public sealed class TargetMachine : IWrapper<LLVMTargetMachineRef>, IDisposable
+    public sealed class TargetMachine : IDisposableWrapper<LLVMTargetMachineRef>, IDisposable
     {
         LLVMTargetMachineRef IWrapper<LLVMTargetMachineRef>.ToHandleType()
         {
             return this._instance;
         }
 
-        void IWrapper<LLVMTargetMachineRef>.MakeHandleOwner()
+        void IDisposableWrapper<LLVMTargetMachineRef>.MakeHandleOwner()
         {
             this._owner = true;
         }

--- a/Type.cs
+++ b/Type.cs
@@ -78,11 +78,7 @@
         {
             return this._instance;
         }
-
-        void IWrapper<LLVMTypeRef>.MakeHandleOwner()
-        {
-        }
-
+        
         private readonly LLVMTypeRef _instance;
 
         internal Type(LLVMTypeRef typeRef)

--- a/Use.cs
+++ b/Use.cs
@@ -6,11 +6,7 @@
         {
             return this._instance;
         }
-
-        void IWrapper<LLVMUseRef>.MakeHandleOwner()
-        {
-        }
-
+        
         private readonly LLVMUseRef _instance;
 
         internal Use(LLVMUseRef instance)


### PR DESCRIPTION
Nothing to add here, just a minor internal change.